### PR TITLE
Fix a bug when GenerateWRounds is used.

### DIFF
--- a/user/crypt/common/salt.go
+++ b/user/crypt/common/salt.go
@@ -94,7 +94,7 @@ func (s *Salt) GenerateWRounds(length, rounds int) []byte {
 
 	roundsText := ""
 	if rounds != s.RoundsDefault {
-		roundsText = "rounds=" + strconv.Itoa(rounds)
+		roundsText = "rounds=" + strconv.Itoa(rounds) + "$"
 	}
 
 	out := make([]byte, len(s.MagicPrefix)+len(roundsText)+length)

--- a/user/crypt/common/salt_test.go
+++ b/user/crypt/common/salt_test.go
@@ -7,12 +7,19 @@
 
 package common
 
-import "testing"
+import (
+	"testing"
+	"strings"
+	"strconv"
+)
 
 var _Salt = &Salt{
 	MagicPrefix: []byte("$foo$"),
 	SaltLenMin:  1,
 	SaltLenMax:  8,
+	RoundsMin: 1000,
+	RoundsMax: 999999999,
+	RoundsDefault: 5000,
 }
 
 func TestGenerateSalt(t *testing.T) {
@@ -33,5 +40,19 @@ func TestGenerateSalt(t *testing.T) {
 	salt = _Salt.Generate(9)
 	if len(salt) != magicPrefixLen+8 {
 		t.Errorf("Expected len 8, got len %d", len(salt))
+	}
+}
+
+func TestGenerateSaltWRounds(t *testing.T) {
+	const rounds = 5001
+	salt := _Salt.GenerateWRounds(_Salt.SaltLenMax, rounds)
+	if salt == nil {
+		t.Errorf("salt should not be nil")
+	}
+
+	expectedPrefix := string(_Salt.MagicPrefix) + "rounds=" + strconv.Itoa(rounds) + "$"
+	if !strings.HasPrefix(string(salt), expectedPrefix) {
+		t.Errorf("salt '%s' should start with prefix '%s' but didn't", salt, expectedPrefix)
+
 	}
 }


### PR DESCRIPTION
- This happens when rounds != RoundsDefault.
- Also added unit test and expanded values in _Salt to support new test.

Without this, you get a "invalid rounds" error from Generate in sha512_crypt is called after GenerateWRounds is used with rounds != RoundsDefault.

