### PR TITLE
go.mod: Clarify retractions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/tredoe/osutil
 
 go 1.16
 
-// Breaking changes
-// curl proxy.golang.org/github.com/tredoe/osutil/@v/list |sort -V
 retract (
 	v1.1.0
 	v1.1.1
@@ -23,5 +21,4 @@ retract (
 	v1.3.4
 	v1.3.5
 	v1.3.6
-	v2.0.0
-)
+) // older releases are no longer installable, as they depended on another module that no longer exists


### PR DESCRIPTION
Add a comment to go.mod that is placed according to the go.mod specification to give some background to the retraction of older releases. Also make the text more clear to explain what happened.

The 2.0.0 version is removed from the list, as it was leading to an error e.g. from go mod tidy:

    go.mod:24:2: retract github.com/tredoe/osutil: version "v2.0.0" invalid: should be v0 or v1, not v2

I made this after looking for an issue with a downstream project that pulls this one as a dependency broke after this. People got a bit worried that something nefarious may have happened here (I did check for clues of malicious code hidden here now, in fact). The new wording will hopefully ease the mind of people hitting this problem in the future. (This can still hit downstreams that don't update and build their modules frequently.)